### PR TITLE
using send() instead of sendto() for tcp

### DIFF
--- a/udptunnel.c
+++ b/udptunnel.c
@@ -379,9 +379,7 @@ static void tcp_to_udp(struct relay *relay)
 
 static void send_handshake(struct relay *relay)
 {
-    if (sendto(relay->tcp_sock, relay->handshake, sizeof(relay->handshake), 0,
-	       (struct sockaddr *) &relay->remote_udpaddr,
-	       sizeof(relay->remote_udpaddr)) < 0)
+    if (send(relay->tcp_sock, relay->handshake, sizeof(relay->handshake), 0) < 0)
 	err_sys("sendto(tcp, handshake)");
 }
 


### PR DESCRIPTION
changing sendto() function call into send() as it's being used on a tcp socket.

> "If sendto() is used on a connection-mode (SOCK_STREAM,  SOCK_SEQPACKET) socket,  the arguments dest_addr and addrlen are ignored (and the error EISCONN may be returned when they are not NULL and 0)"

 from Linux Programmer's Manual.